### PR TITLE
Take network_id as parameter to avoid exception even if it is not defined in global scope

### DIFF
--- a/backends/farm_and_pool.py
+++ b/backends/farm_and_pool.py
@@ -56,7 +56,7 @@ def update_farms(network_id):
     except Exception as e:
         print("Error occurred when update to Redis, cancel pipe. Error is: ", e)
         
-def internal_get_token_metadata(conn, contract_id):
+def internal_get_token_metadata(network_id, conn, contract_id):
     metadata_obj = {
         "spec":"", 
         "name": contract_id, 
@@ -135,7 +135,7 @@ def internal_get_pools(network_id: str) ->list:
                     # pool["token_symbols"].append(token_metadata[x]["symbol"])
                 else:
                     time.sleep(0.1)
-                    metadata_obj = internal_get_token_metadata(conn, x)
+                    metadata_obj = internal_get_token_metadata(network_id, conn, x)
                     pool["token_symbols"].append(metadata_obj["symbol"])
                     token_metadata[x] = metadata_obj
 
@@ -147,7 +147,7 @@ def internal_get_pools(network_id: str) ->list:
         pools.clear()
     return pools
 
-def internal_add_volume_info(top_pools: dict):
+def internal_add_volume_info(network_id: str, top_pools: dict):
     contract = Cfg.NETWORK[network_id]["REF_CONTRACT"]
     try:
         conn = MultiNodeJsonProvider(network_id)
@@ -209,7 +209,7 @@ def internal_pools_to_redis(network_id: str, pools: list):
             print("Import Pools to Redis OK.")
 
             # add vol info into top-pools
-            internal_add_volume_info(tops)
+            internal_add_volume_info(network_id, tops)
             # pour top-pools data to redis
             conn.begin_pipe()
             for key, top_pool in tops.items():

--- a/backends/top_pools.py
+++ b/backends/top_pools.py
@@ -57,7 +57,7 @@ def update_farms(network_id):
         print("Error occurred when update to Redis, cancel pipe. Error is: ", e)
 
 
-def internal_get_token_metadata(conn, contract_id):
+def internal_get_token_metadata(network_id, conn, contract_id):
     metadata_obj = {
         "spec": "",
         "name": contract_id,
@@ -147,7 +147,7 @@ def internal_get_pools(network_id: str, number: int) -> list:
                     # pool["token_symbols"].append(token_metadata[x]["symbol"])
                 else:
                     time.sleep(0.1)
-                    metadata_obj = internal_get_token_metadata(conn, x)
+                    metadata_obj = internal_get_token_metadata(network_id, conn, x)
                     pool["token_symbols"].append(metadata_obj["symbol"])
                     token_metadata[x] = metadata_obj
 
@@ -160,7 +160,7 @@ def internal_get_pools(network_id: str, number: int) -> list:
     return pools
 
 
-def internal_add_volume_info(top_pools: dict):
+def internal_add_volume_info(network_id: str, top_pools: dict):
     contract = Cfg.NETWORK[network_id]["REF_CONTRACT"]
     try:
         conn = MultiNodeJsonProvider(network_id)
@@ -233,7 +233,7 @@ def update_top_pools(network_id: str):
 
             # add vol info into top-pools
             # start_time_3 = int(time.time())
-            # internal_add_volume_info(tops)
+            # internal_add_volume_info(network_id, tops)
             # end_time_3 = int(time.time())
             # print("internal_add_volume_info consuming time:{}", start_time_3 - end_time_3)
             # pour top-pools data to redis

--- a/backends/update_pools.py
+++ b/backends/update_pools.py
@@ -57,7 +57,7 @@ def update_farms(network_id):
         print("Error occurred when update to Redis, cancel pipe. Error is: ", e)
 
 
-def internal_get_token_metadata(conn, contract_id):
+def internal_get_token_metadata(network_id, conn, contract_id):
     metadata_obj = {
         "spec": "",
         "name": contract_id,
@@ -149,7 +149,7 @@ def internal_get_pools(network_id: str, number: int) -> list:
                     # pool["token_symbols"].append(token_metadata[x]["symbol"])
                 else:
                     time.sleep(0.1)
-                    metadata_obj = internal_get_token_metadata(conn, x)
+                    metadata_obj = internal_get_token_metadata(network_id, conn, x)
                     pool["token_symbols"].append(metadata_obj["symbol"])
                     token_metadata[x] = metadata_obj
 
@@ -162,7 +162,7 @@ def internal_get_pools(network_id: str, number: int) -> list:
     return pools
 
 
-def internal_add_volume_info(top_pools: dict):
+def internal_add_volume_info(network_id: str, top_pools: dict):
     contract = Cfg.NETWORK[network_id]["REF_CONTRACT"]
     try:
         conn = MultiNodeJsonProvider(network_id)
@@ -227,7 +227,7 @@ def internal_pools_to_redis(network_id: str, pools: list, number: int):
             print("Import Pools to Redis OK.")
 
             # add vol info into top-pools
-            # internal_add_volume_info(tops)
+            # internal_add_volume_info(network_id, tops)
             # pour top-pools data to redis
             # conn.begin_pipe()
             # for key, top_pool in tops.items():


### PR DESCRIPTION
I was trying to run the indexer helper with some modification and I was getting this error in the logs when I called `update_pools("mainnet")` function from another python file.

```Error: name 'network_id' is not defined```

Hence, I think this minor change would be helpful for other developers like me to use the software.