### PR TITLE
fix sql safety in burrow liquidate log query

### DIFF
--- a/db_provider.py
+++ b/db_provider.py
@@ -1514,8 +1514,10 @@ def query_burrow_liquidate_log(network_id, account_id, page_number, page_size):
     db_conn = get_db_connect(network_id)
     receipt_sql = "select receipt_id from burrow_event_log where liquidation_account_id = %s and " \
                   "`event` = 'liquidate' order by `timestamp` desc limit %s, %s"
-    liquidate_sql = f"select `event`, amount, token_id, `timestamp`, receipt_id, is_read, update_time, position from " \
-                    f"burrow_event_log where receipt_id in ('%s') order by `timestamp` desc"
+    liquidate_sql = (
+        "select `event`, amount, token_id, `timestamp`, receipt_id, is_read, update_time, position from "
+        "burrow_event_log where receipt_id in ({}) order by `timestamp` desc"
+    )
     sql_count = "select count(*) as total_number from burrow_event_log where liquidation_account_id = %s " \
                 "and `event` = 'liquidate'"
     not_read_sql_count = "select count(*) as total_number from burrow_event_log where liquidation_account_id = %s " \
@@ -1526,14 +1528,14 @@ def query_burrow_liquidate_log(network_id, account_id, page_number, page_size):
         receipt_log = cursor.fetchall()
         receipt_ids = [entry['receipt_id'] for entry in receipt_log]
         if receipt_ids:
-            receipt_ids_placeholder = "','".join(map(str, receipt_ids))
-            cursor.execute(liquidate_sql % receipt_ids_placeholder)
+            placeholders = ",".join(["%s"] * len(receipt_ids))
+            cursor.execute(liquidate_sql.format(placeholders), tuple(receipt_ids))
             liquidate_log_list = cursor.fetchall()
         else:
             liquidate_log_list = []
-        cursor.execute(sql_count, account_id)
+        cursor.execute(sql_count, (account_id,))
         burrow_log_count = cursor.fetchone()
-        cursor.execute(not_read_sql_count, account_id)
+        cursor.execute(not_read_sql_count, (account_id,))
         not_read_count = cursor.fetchone()
         ret_liquidate_log = handel_liquidate_log_data(liquidate_log_list, account_id)
         return ret_liquidate_log, burrow_log_count["total_number"], not_read_count["total_number"]


### PR DESCRIPTION
## what changed

- replaced string-built `IN ('...')` with a parameterized `IN (%s, %s, ...)` so receipt ids are never interpolated into raw sql
- use `(account_id,)` for the count queries in the same handler (correct single-arg tuple for pymysql)

## why

receipt ids were joined into the query text. any value containing a quote could break out of the string literal (second-order risk if ids are ever untrusted or malformed). parameterized queries avoid that class of bug entirely.

---

made by mooncitydev